### PR TITLE
Add design time migration apply

### DIFF
--- a/NTG.Agent.Orchestrator/DesignTimeAgentDbContextFactory.cs
+++ b/NTG.Agent.Orchestrator/DesignTimeAgentDbContextFactory.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using NTG.Agent.Orchestrator.Data;
+
+namespace NTG.Agent.Orchestrator;
+
+public class DesignTimeAgentDbContextFactory : IDesignTimeDbContextFactory<AgentDbContext>
+{
+    private readonly string? _environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+    public AgentDbContext CreateDbContext(string[] args)
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddUserSecrets<Program>()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile($"appsettings.{_environment}.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var builder = new DbContextOptionsBuilder<AgentDbContext>();
+
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+
+        builder.UseSqlServer(connectionString, x => x.MigrationsAssembly(typeof(AgentDbContext).Assembly.FullName)
+            .EnableRetryOnFailure());
+
+        return new AgentDbContext(builder.Options);
+    }
+}
+


### PR DESCRIPTION
Currently `AgentDbContext` only allows us to apply new migrations during runtime. In some cases, we might need a derived DbContext instance to be created at design time in order to gather details about the application's entity types and how they map to a database schema.

More in https://learn.microsoft.com/en-us/ef/core/cli/dbcontext-creation?tabs=dotnet-core-cli