### PR TITLE
WebClient: Handle error when no userId and no sessionId

### DIFF
--- a/NTG.Agent.Orchestrator/Controllers/ConversationsController.cs
+++ b/NTG.Agent.Orchestrator/Controllers/ConversationsController.cs
@@ -6,7 +6,6 @@ using NTG.Agent.Orchestrator.Extentions;
 using NTG.Agent.Orchestrator.Models.Chat;
 using NTG.Agent.Shared.Dtos.Chats;
 using NTG.Agent.Shared.Dtos.Conversations;
-using System;
 
 namespace NTG.Agent.Orchestrator.Controllers;
 
@@ -93,13 +92,12 @@ public class ConversationsController : ControllerBase
     {
         Guid? userId = User.GetUserId();
         bool isAuthorized = false;
-
         if (userId.HasValue)
         {
             isAuthorized = await _context.Conversations
                 .AnyAsync(c => c.Id == id && c.UserId == userId.Value);
         }
-        else
+        else if (!string.IsNullOrWhiteSpace(currentSessionId))
         {
             if (!Guid.TryParse(currentSessionId, out Guid sessionId))
             {
@@ -108,6 +106,10 @@ public class ConversationsController : ControllerBase
 
             isAuthorized = await _context.Conversations
                 .AnyAsync(c => c.Id == id && c.SessionId == sessionId);
+        }
+        else
+        {
+            isAuthorized = false;
         }
 
         if (!isAuthorized)

--- a/NTG.Agent.Orchestrator/Controllers/ConversationsController.cs
+++ b/NTG.Agent.Orchestrator/Controllers/ConversationsController.cs
@@ -107,9 +107,6 @@ public class ConversationsController : ControllerBase
             isAuthorized = await _context.Conversations
                 .AnyAsync(c => c.Id == id && c.SessionId == sessionId);
         }
-        else
-        {
-        }
 
         if (!isAuthorized)
         {

--- a/NTG.Agent.Orchestrator/Controllers/ConversationsController.cs
+++ b/NTG.Agent.Orchestrator/Controllers/ConversationsController.cs
@@ -109,7 +109,6 @@ public class ConversationsController : ControllerBase
         }
         else
         {
-            isAuthorized = false;
         }
 
         if (!isAuthorized)


### PR DESCRIPTION
Currently, there is an unhandled error where both userId and sessionId are NULL
This PR is to fix that.