### PR TITLE
feat: add idle container shutdown to reclaim RAM and harden error han…

### DIFF
--- a/NTG.Agent.Orchestrator/Controllers/DocumentsController.cs
+++ b/NTG.Agent.Orchestrator/Controllers/DocumentsController.cs
@@ -158,10 +158,14 @@ public class DocumentsController : ControllerBase
                 }
                 results.Add(new UploadDocumentResult(file.FileName, Success: true, ErrorMessage: null, DocumentId: document.Id));
             }
+            catch (OperationCanceledException)
+            {
+                throw; // Propagate cancellation — don't swallow it as an upload error.
+            }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to begin ingestion for {FileName} (agentId={AgentId})", file.FileName, agentId);
-                results.Add(new UploadDocumentResult(file.FileName, Success: false, ErrorMessage: ex.Message, DocumentId: null));
+                _logger.LogError(ex, "Unexpected error importing {FileName} (agentId={AgentId})", file.FileName, agentId);
+                results.Add(new UploadDocumentResult(file.FileName, Success: false, ErrorMessage: $"Unexpected error: {ex.Message}", DocumentId: null));
             }
         }
 

--- a/NTG.Agent.Orchestrator/Models/Configuration/LightRagSettings.cs
+++ b/NTG.Agent.Orchestrator/Models/Configuration/LightRagSettings.cs
@@ -56,4 +56,12 @@ public class LightRagSettings
     public int MaxAsync { get; set; } = 8;
     public int MaxParallelInsert { get; set; } = 2;
     public int EmbeddingFuncMaxAsync { get; set; } = 8;
+
+    // ---- Idle container shutdown ------------------------------------------------
+    // When a per-agent LightRAG container has not received a request for this many
+    // minutes, it is stopped to reclaim RAM. Set to 0 or negative to disable.
+    public int IdleTimeoutMinutes { get; set; } = 30;
+
+    // How often the idle-shutdown background service checks for stale containers.
+    public int IdleCheckIntervalMinutes { get; set; } = 5;
 }

--- a/NTG.Agent.Orchestrator/Program.cs
+++ b/NTG.Agent.Orchestrator/Program.cs
@@ -130,8 +130,10 @@ builder.Services.AddHttpClient(nameof(LightRagClient), c =>
 // factory resolves a per-agent client, and the reconciler ensures containers exist
 // for every agent on startup.
 builder.Services.AddSingleton<ILightRagContainerManager, LightRagContainerManager>();
+builder.Services.AddSingleton<LightRagContainerAccessTracker>();
 builder.Services.AddScoped<LightRagClientFactory>();
 builder.Services.AddHostedService<LightRagReconcilerHostedService>();
+builder.Services.AddHostedService<LightRagContainerIdleShutdownService>();
 // Event-driven worker: parks while idle and wakes (via IngestionStatusSignal) when an upload
 // begins, polling LightRAG until every Processing document reaches Completed/Failed.
 builder.Services.AddSingleton<IngestionStatusSignal>();

--- a/NTG.Agent.Orchestrator/Services/Knowledge/ILightRagContainerManager.cs
+++ b/NTG.Agent.Orchestrator/Services/Knowledge/ILightRagContainerManager.cs
@@ -21,4 +21,10 @@ public interface ILightRagContainerManager
 
     /// <summary>Stops and removes the agent's container. No-op if it does not exist.</summary>
     Task StopAndRemoveContainerAsync(Guid agentId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stops the agent's container without removing it, so it can be restarted later
+    /// via <see cref="EnsureContainerAsync"/>. No-op if the container is not running.
+    /// </summary>
+    Task StopContainerAsync(Guid agentId, CancellationToken cancellationToken = default);
 }

--- a/NTG.Agent.Orchestrator/Services/Knowledge/LightRagClientFactory.cs
+++ b/NTG.Agent.Orchestrator/Services/Knowledge/LightRagClientFactory.cs
@@ -10,11 +10,18 @@ namespace NTG.Agent.Orchestrator.Services.Knowledge;
 /// container (<c>http://localhost:{Agent.LightRagPort}</c>). This is what scopes every
 /// chat/upload call to the agent's own LightRAG workspace instead of a shared endpoint.
 /// Scoped: caches resolved clients for the lifetime of the request scope.
+/// <para>
+/// If the container is not running (e.g. stopped by idle shutdown), this factory will
+/// restart it via <see cref="ILightRagContainerManager.EnsureContainerAsync"/> and update
+/// the stored port before creating the client.
+/// </para>
 /// </summary>
 public sealed class LightRagClientFactory
 {
     private readonly AgentDbContext _db;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILightRagContainerManager _containerManager;
+    private readonly LightRagContainerAccessTracker _accessTracker;
     private readonly LightRagSettings _settings;
     private readonly ILoggerFactory _loggerFactory;
     private readonly Dictionary<Guid, LightRagClient> _cache = [];
@@ -22,11 +29,15 @@ public sealed class LightRagClientFactory
     public LightRagClientFactory(
         AgentDbContext db,
         IHttpClientFactory httpClientFactory,
+        ILightRagContainerManager containerManager,
+        LightRagContainerAccessTracker accessTracker,
         IOptions<LightRagSettings> settings,
         ILoggerFactory loggerFactory)
     {
         _db = db;
         _httpClientFactory = httpClientFactory;
+        _containerManager = containerManager;
+        _accessTracker = accessTracker;
         _settings = settings.Value;
         _loggerFactory = loggerFactory;
     }
@@ -34,18 +45,32 @@ public sealed class LightRagClientFactory
     public async Task<LightRagClient> GetClientAsync(Guid agentId, CancellationToken cancellationToken = default)
     {
         if (_cache.TryGetValue(agentId, out var cached))
+        {
+            _accessTracker.Touch(agentId);
             return cached;
+        }
 
         var port = await _db.Agents
             .Where(a => a.Id == agentId)
             .Select(a => a.LightRagPort)
             .FirstOrDefaultAsync(cancellationToken);
 
-        if (port is not > 0)
-            throw new InvalidOperationException(
-                $"Agent '{agentId}' has no provisioned LightRAG container yet (LightRagPort is not set).");
+        // If the port is missing or the container is not reachable, ensure it is running.
+        // This handles the case where idle shutdown stopped the container.
+        if (port is not > 0 || !await IsContainerReachableAsync(port.Value))
+        {
+            port = await _containerManager.EnsureContainerAsync(agentId, port, cancellationToken);
 
-        // Named client inherits the standard resilience handler with the LightRagClient
+            // Persist the (possibly new) port so subsequent requests skip the health check.
+            var agent = await _db.Agents.FindAsync(new object[] { agentId }, cancellationToken);
+            if (agent is not null && agent.LightRagPort != port)
+            {
+                agent.LightRagPort = port;
+                await _db.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        // Named client inherits the standard resilience handler with the LightRAGClient
         // overrides (2-min attempt timeout, no retries) configured in Program.cs.
         var http = _httpClientFactory.CreateClient(nameof(LightRagClient));
         http.BaseAddress = new Uri($"http://localhost:{port}");
@@ -54,6 +79,27 @@ public sealed class LightRagClientFactory
 
         var client = new LightRagClient(http, _loggerFactory.CreateLogger<LightRagClient>());
         _cache[agentId] = client;
+        _accessTracker.Touch(agentId);
         return client;
+    }
+
+    /// <summary>
+    /// Quick TCP check to see if a container is accepting connections on the given port.
+    /// Used to detect containers that were stopped by idle shutdown.
+    /// </summary>
+    private static async Task<bool> IsContainerReachableAsync(int port)
+    {
+        try
+        {
+            using var tcpClient = new System.Net.Sockets.TcpClient();
+            var connectTask = tcpClient.ConnectAsync(System.Net.IPAddress.Loopback, port);
+            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(2));
+            var completed = await Task.WhenAny(connectTask, timeoutTask);
+            return completed == connectTask && tcpClient.Connected;
+        }
+        catch
+        {
+            return false;
+        }
     }
 }

--- a/NTG.Agent.Orchestrator/Services/Knowledge/LightRagContainerAccessTracker.cs
+++ b/NTG.Agent.Orchestrator/Services/Knowledge/LightRagContainerAccessTracker.cs
@@ -1,0 +1,43 @@
+namespace NTG.Agent.Orchestrator.Services.Knowledge;
+
+/// <summary>
+/// Thread-safe singleton that tracks the last time each agent's LightRAG container
+/// was accessed. Used by <see cref="LightRagContainerIdleShutdownService"/> to decide
+/// when a container can be stopped to reclaim RAM.
+/// </summary>
+public sealed class LightRagContainerAccessTracker
+{
+    private readonly Dictionary<Guid, DateTime> _lastAccess = new();
+    private readonly object _lock = new();
+
+    /// <summary>Record that the given agent's container was just accessed.</summary>
+    public void Touch(Guid agentId)
+    {
+        lock (_lock)
+        {
+            _lastAccess[agentId] = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Returns the last access time for the given agent, or <c>null</c> if the agent
+    /// has never been tracked. Callers should treat a missing entry as "unknown"
+    /// (i.e. don't shut down a container we've never seen accessed).
+    /// </summary>
+    public DateTime? GetLastAccess(Guid agentId)
+    {
+        lock (_lock)
+        {
+            return _lastAccess.TryGetValue(agentId, out var ts) ? ts : null;
+        }
+    }
+
+    /// <summary>Remove the tracking entry for an agent (e.g. after its container is removed).</summary>
+    public void Remove(Guid agentId)
+    {
+        lock (_lock)
+        {
+            _lastAccess.Remove(agentId);
+        }
+    }
+}

--- a/NTG.Agent.Orchestrator/Services/Knowledge/LightRagContainerIdleShutdownService.cs
+++ b/NTG.Agent.Orchestrator/Services/Knowledge/LightRagContainerIdleShutdownService.cs
@@ -1,0 +1,132 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NTG.Agent.Orchestrator.Data;
+using NTG.Agent.Orchestrator.Models.Configuration;
+
+namespace NTG.Agent.Orchestrator.Services.Knowledge;
+
+/// <summary>
+/// Background service that periodically checks whether LightRAG containers have been
+/// idle beyond the configured timeout and stops them to reclaim RAM. Stopped containers
+/// are automatically restarted on the next request via
+/// <see cref="LightRagClientFactory.GetClientAsync"/>.
+/// </summary>
+public sealed class LightRagContainerIdleShutdownService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILightRagContainerManager _containerManager;
+    private readonly LightRagContainerAccessTracker _accessTracker;
+    private readonly LightRagSettings _settings;
+    private readonly ILogger<LightRagContainerIdleShutdownService> _logger;
+
+    public LightRagContainerIdleShutdownService(
+        IServiceProvider serviceProvider,
+        ILightRagContainerManager containerManager,
+        LightRagContainerAccessTracker accessTracker,
+        IOptions<LightRagSettings> settings,
+        ILogger<LightRagContainerIdleShutdownService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _containerManager = containerManager;
+        _accessTracker = accessTracker;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Idle shutdown is disabled when timeout is zero or negative.
+        if (_settings.IdleTimeoutMinutes <= 0)
+        {
+            _logger.LogInformation(
+                "LightRAG idle shutdown is disabled (IdleTimeoutMinutes={Timeout}).",
+                _settings.IdleTimeoutMinutes);
+            return;
+        }
+
+        var interval = TimeSpan.FromMinutes(_settings.IdleCheckIntervalMinutes);
+        _logger.LogInformation(
+            "LightRAG idle shutdown service started: timeout={Timeout}min, check interval={Interval}min.",
+            _settings.IdleTimeoutMinutes, _settings.IdleCheckIntervalMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(interval, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            try
+            {
+                await ShutdownIdleContainersAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "LightRAG idle shutdown service: error during idle check.");
+            }
+        }
+
+        _logger.LogInformation("LightRAG idle shutdown service stopped.");
+    }
+
+    private async Task ShutdownIdleContainersAsync(CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AgentDbContext>();
+
+        var agents = await db.Agents.ToListAsync(ct);
+        var timeout = TimeSpan.FromMinutes(_settings.IdleTimeoutMinutes);
+        var now = DateTime.UtcNow;
+        var shutdownCount = 0;
+
+        foreach (var agent in agents)
+        {
+            // Skip agents that don't have a container yet.
+            if (agent.LightRagPort is null or 0)
+                continue;
+
+            var lastAccess = _accessTracker.GetLastAccess(agent.Id);
+
+            // If we've never tracked access for this agent, don't shut it down —
+            // it might have been just created or reconciled.
+            if (lastAccess is null)
+                continue;
+
+            var idleDuration = now - lastAccess.Value;
+            if (idleDuration < timeout)
+                continue;
+
+            _logger.LogInformation(
+                "LightRAG idle shutdown: agent {AgentId} has been idle for {IdleMinutes:F0}min " +
+                "(threshold={Threshold}min). Stopping container.",
+                agent.Id, idleDuration.TotalMinutes, _settings.IdleTimeoutMinutes);
+
+            try
+            {
+                await _containerManager.StopContainerAsync(agent.Id, ct);
+                _accessTracker.Remove(agent.Id);
+                shutdownCount++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "LightRAG idle shutdown: failed to stop container for agent {AgentId}.",
+                    agent.Id);
+            }
+        }
+
+        if (shutdownCount > 0)
+        {
+            _logger.LogInformation(
+                "LightRAG idle shutdown: stopped {Count} idle container(s).", shutdownCount);
+        }
+    }
+}

--- a/NTG.Agent.Orchestrator/Services/Knowledge/LightRagContainerManager.cs
+++ b/NTG.Agent.Orchestrator/Services/Knowledge/LightRagContainerManager.cs
@@ -179,6 +179,42 @@ public sealed class LightRagContainerManager : ILightRagContainerManager, IDispo
         }
     }
 
+    public async Task StopContainerAsync(Guid agentId, CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            var name = ContainerName(agentId);
+            var existing = await FindContainerAsync(name, cancellationToken);
+            if (existing is null)
+            {
+                _logger.LogInformation("LightRagContainerManager: no container {Name} to stop.", name);
+                return;
+            }
+
+            var inspect = await _docker.Containers.InspectContainerAsync(existing.ID, cancellationToken);
+            if (inspect.State?.Running != true)
+            {
+                _logger.LogInformation("LightRagContainerManager: {Name} is already stopped.", name);
+                return;
+            }
+
+            try
+            {
+                await _docker.Containers.StopContainerAsync(existing.ID, new ContainerStopParameters { WaitBeforeKillSeconds = 10 }, cancellationToken);
+                _logger.LogInformation("LightRagContainerManager: stopped idle container {Name}.", name);
+            }
+            catch (DockerApiException ex)
+            {
+                _logger.LogWarning(ex, "LightRagContainerManager: stop {Name} failed.", name);
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
     private async Task<ContainerListResponse?> FindContainerAsync(string name, CancellationToken ct)
     {
         var all = await _docker.Containers.ListContainersAsync(new ContainersListParameters { All = true }, ct);
@@ -416,5 +452,9 @@ public sealed class LightRagContainerManager : ILightRagContainerManager, IDispo
         return ReadPublishedPort(inspect, "5432/tcp");
     }
 
-    public void Dispose() => _docker.Dispose();
+    public void Dispose()
+    {
+        _gate.Dispose();
+        _docker.Dispose();
+    }
 }

--- a/NTG.Agent.Orchestrator/Services/Knowledge/LightRagFileStore.cs
+++ b/NTG.Agent.Orchestrator/Services/Knowledge/LightRagFileStore.cs
@@ -58,6 +58,12 @@ public class LightRagFileStore
         }
     }
 
-    private string BuildFilePath(Guid agentId, Guid documentId, string fileName)
-        => Path.Combine(_basePath, agentId.ToString(), $"{documentId}_{fileName}");
+private string BuildFilePath(Guid agentId, Guid documentId, string fileName)
+    {
+        // Sanitize to prevent path traversal — strip any directory components from fileName.
+        var safeFileName = Path.GetFileName(fileName);
+        if (string.IsNullOrWhiteSpace(safeFileName))
+            throw new ArgumentException("File name must not be empty or whitespace.", nameof(fileName));
+        return Path.Combine(_basePath, agentId.ToString(), $"{documentId}_{safeFileName}");
+    }
 }

--- a/NTG.Agent.Orchestrator/Services/Knowledge/LightRagKnowledge.cs
+++ b/NTG.Agent.Orchestrator/Services/Knowledge/LightRagKnowledge.cs
@@ -143,6 +143,16 @@ public class LightRagKnowledge : IKnowledgeService
     {
         // Each agent has its own container/workspace, so this query only sees this
         // agent's documents. Hybrid mode enables local + global graph search with re-ranking.
+        //
+        // NOTE: LightRAG's /query endpoint does not support tag-based filtering. Tags are
+        // accepted for interface compatibility but are not applied. Per-agent workspace
+        // isolation already scopes results to a single agent's documents.
+        if (tags is { Count: > 0 })
+        {
+            _logger.LogWarning("LightRagKnowledge.SearchAsync: tag-based filtering is not supported by LightRAG; " +
+                "tags were provided but will be ignored for agentId={AgentId}.", agentId);
+        }
+
         var client = await _clientFactory.GetClientAsync(agentId, cancellationToken);
         var contextText = await client.QueryAsync(query, _settings.TopK, "hybrid", true, cancellationToken);
         return new KnowledgeSearchResponse(


### PR DESCRIPTION
…dling

- Add LightRagContainerAccessTracker + LightRagContainerIdleShutdownService to stop containers idle >30min (configurable via IdleTimeoutMinutes)
- LightRagClientFactory auto-restarts stopped containers on next request
- Add StopContainerAsync to ILightRagContainerManager (stop without remove)
- Fix: catch OperationCanceledException before catch-all in upload loop
- Fix: guard against null/empty fileName in LightRagFileStore path traversal
- Log warning when tags are provided but unsupported by LightRAG