### PR TITLE
Bump sonarscan-dotnet to v2.5.1 (Java 21 scanner)

### DIFF
--- a/.github/workflows/ntg-agent-ci.yml
+++ b/.github/workflows/ntg-agent-ci.yml
@@ -39,7 +39,7 @@ jobs:
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
       - name: SonarCloud Analysis (with .NET scanner)
-        uses: highbyte/sonarscan-dotnet@252f699a9c4e005bf3902d44a1c6c0aea43c678e # v2.5.0
+        uses: highbyte/sonarscan-dotnet@8642efb8793ae4a89bd1e6cdf0a1aef1e582f9bb # v2.5.1
         with:
           sonarProjectKey: ${{ secrets.SONAR_PROJECT_KEY }}
           sonarProjectName: ntg-agent


### PR DESCRIPTION
## Why

Every CI run currently fails at the SonarCloud step:

> The version of Java (17) used to run this analysis is deprecated, and SonarQube Cloud no longer supports it. Please upgrade to Java 21 or later.

SonarQube Cloud dropped Java 17 scanner support. The `highbyte/sonarscan-dotnet@v2.5.0` container action bundles JRE 17, so the scanner engine aborts after build + tests succeed (e.g. [this run](https://github.com/nashtech-garage/ntg-agent/actions/runs/29889938195/job/88828166940) on #277).

## What

One line: bump the action pin v2.5.0 → v2.5.1. The upstream release's only change is `JRE_VERSION` 17 → 21 in the container ([release notes](https://github.com/highbyte/sonarscan-dotnet/releases/tag/v2.5.1)). Still pinned by commit SHA, same convention as before.

## Verification

- Upstream v2.5.1 Dockerfile confirmed: `JRE_VERSION=21`, scanner tool 11.0.0 unchanged
- This PR's own CI run is the live test — the SonarCloud step should now reach analysis

Once merged, feature branches (e.g. #277) pick up the fix by syncing with main.